### PR TITLE
feat: switch all voice_active_dog examples to Piper TTS by default

### DIFF
--- a/examples/19_voice_active_dog_ollama.py
+++ b/examples/19_voice_active_dog_ollama.py
@@ -3,6 +3,25 @@ from pidog.llm import Ollama as LLM
 from pidog.dual_touch import TouchStyle
 from voice_active_dog import VoiceActiveDog
 
+# ── TTS engines ──────────────────────────────────────────────────────────
+# Pick one. The VoiceAssistant accepts any TTS instance via the `tts=` parameter.
+
+# Default: Piper — local neural TTS, offline, fast
+from pidog.tts import Piper
+tts = Piper(model="en_US-ryan-low")
+
+# EdgeTTS — free cloud TTS, 100+ voices, no API key
+# from pidog.tts import EdgeTTS
+# tts = EdgeTTS(voice="en-US-AriaNeural")
+
+# Espeak — compact offline TTS, robotic, fastest
+# from pidog.tts import Espeak
+# tts = Espeak()
+
+# Pico2Wave — compact offline TTS
+# from pidog.tts import Pico2Wave
+# tts = Pico2Wave()
+
 # If Ollama runs on the same Raspberry Pi, use "localhost".
 # If it runs on another computer in your LAN, replace with that computer's IP address.
 llm = LLM(
@@ -29,7 +48,6 @@ HATE_TOUCH_STYLES = [TouchStyle.REAR_TO_FRONT]
 WITH_IMAGE = False
 
 # Set models and languages
-TTS_MODEL = "en_US-ryan-low"
 STT_LANGUAGE = "en-us"
 
 # Enable keyboard input
@@ -97,7 +115,7 @@ vad = VoiceActiveDog(
     hate_touch_styles=HATE_TOUCH_STYLES,
     with_image=WITH_IMAGE,
     stt_language=STT_LANGUAGE,
-    tts_model=TTS_MODEL,
+    tts=tts,
     keyboard_enable=KEYBOARD_ENABLE,
     wake_enable=WAKE_ENABLE,
     wake_word=WAKE_WORD,

--- a/examples/20_voice_active_dog_doubao_cn.py
+++ b/examples/20_voice_active_dog_doubao_cn.py
@@ -4,6 +4,25 @@ from secret import DOUBAO_API_KEY as API_KEY
 from pidog.dual_touch import TouchStyle
 from voice_active_dog import VoiceActiveDog
 
+# ── TTS engines ──────────────────────────────────────────────────────────
+# Pick one. The VoiceAssistant accepts any TTS instance via the `tts=` parameter.
+
+# Default: Piper — local neural TTS, offline, fast
+from pidog.tts import Piper
+tts = Piper(model="zh_CN-huayan-x_low")
+
+# EdgeTTS — free cloud TTS, 100+ voices, no API key
+# from pidog.tts import EdgeTTS
+# tts = EdgeTTS(voice="zh-CN-XiaoxiaoNeural")
+
+# Espeak — compact offline TTS, robotic, fastest
+# from pidog.tts import Espeak
+# tts = Espeak()
+
+# Pico2Wave — compact offline TTS
+# from pidog.tts import Pico2Wave
+# tts = Pico2Wave()
+
 llm = LLM(
     api_key=API_KEY,
     model="doubao-seed-1-6-250615",
@@ -28,7 +47,6 @@ HATE_TOUCH_STYLES = [TouchStyle.REAR_TO_FRONT]
 WITH_IMAGE = True
 
 # 设置模型和语言
-TTS_MODEL = "zh_CN-huayan-x_low"
 STT_LANGUAGE = "cn"
 
 # 是否开启键盘输入
@@ -93,7 +111,7 @@ vad = VoiceActiveDog(
     hate_touch_styles=HATE_TOUCH_STYLES,
     with_image=WITH_IMAGE,
     stt_language=STT_LANGUAGE,
-    tts_model=TTS_MODEL,
+    tts=tts,
     keyboard_enable=KEYBOARD_ENABLE,
     wake_enable=WAKE_ENABLE,
     wake_word=WAKE_WORD,

--- a/examples/20_voice_active_dog_gpt.py
+++ b/examples/20_voice_active_dog_gpt.py
@@ -4,6 +4,25 @@ from secret import OPENAI_API_KEY as API_KEY
 from pidog.dual_touch import TouchStyle
 from voice_active_dog import VoiceActiveDog
 
+# ── TTS engines ──────────────────────────────────────────────────────────
+# Pick one. The VoiceAssistant accepts any TTS instance via the `tts=` parameter.
+
+# Default: Piper — local neural TTS, offline, fast
+from pidog.tts import Piper
+tts = Piper(model="en_US-ryan-low")
+
+# EdgeTTS — free cloud TTS, 100+ voices, no API key
+# from pidog.tts import EdgeTTS
+# tts = EdgeTTS(voice="en-US-AriaNeural")
+
+# Espeak — compact offline TTS, robotic, fastest
+# from pidog.tts import Espeak
+# tts = Espeak()
+
+# Pico2Wave — compact offline TTS
+# from pidog.tts import Pico2Wave
+# tts = Pico2Wave()
+
 llm = LLM(
     api_key=API_KEY,
     model="gpt-4o-mini",
@@ -28,7 +47,6 @@ HATE_TOUCH_STYLES = [TouchStyle.REAR_TO_FRONT]
 WITH_IMAGE = True
 
 # Set models and languages
-TTS_MODEL = "en_US-ryan-low"
 STT_LANGUAGE = "en-us"
 
 # Enable keyboard input
@@ -96,7 +114,7 @@ vad = VoiceActiveDog(
     hate_touch_styles=HATE_TOUCH_STYLES,
     with_image=WITH_IMAGE,
     stt_language=STT_LANGUAGE,
-    tts_model=TTS_MODEL,
+    tts=tts,
     keyboard_enable=KEYBOARD_ENABLE,
     wake_enable=WAKE_ENABLE,
     wake_word=WAKE_WORD,

--- a/examples/voice_active_dog.py
+++ b/examples/voice_active_dog.py
@@ -29,7 +29,6 @@ WITH_IMAGE = True
 
 # Set models and languages
 LLM_MODEL = "gpt-4o-mini"
-TTS_MODEL = "en_US-ryan-low"
 STT_LANGUAGE = "en-us"
 
 # Enable wake word


### PR DESCRIPTION
## Summary

Switch all voice_active_dog examples from legacy `tts_model` parameter to TTS injection (`tts=tts`) with Piper as the default TTS engine.

## Changes

- **voice_active_dog.py** (base class): Remove legacy `TTS_MODEL` variable
- **20_voice_active_dog_gpt.py**: Add Piper TTS injection as default, comment out EdgeTTS/Espeak/Pico2Wave alternatives
- **19_voice_active_dog_ollama.py**: Add Piper TTS injection as default, comment out alternatives
- **20_voice_active_dog_doubao_cn.py**: Add Piper TTS injection with `zh_CN-huayan-x_low` model, comment out alternatives

All examples now use `from pidog.tts import Piper` as the default TTS engine, with other TTS options available via uncommenting.

## Test install command

N/A — example file changes only, no install script changes.